### PR TITLE
made the yaml tag configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module "github.com/Velocidex/yaml/v2"
+module "github.com/hzakher/yaml/v2"
 
 require (
         "gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405

--- a/yaml.go
+++ b/yaml.go
@@ -16,9 +16,18 @@ import (
 )
 
 var (
-	// Most struct in the wild use json so we use it too.
-	YAML_TAG = "json"
+	// default tag value.	
+	yaml_tag = "yaml"
 )
+
+// NewDecoder returns a new decoder that reads from r.
+//
+// The decoder introduces its own buffering and may read
+// data from r beyond the YAML values requested.
+func SetTag(tag string) {
+	yaml_tag = tag
+}
+
 
 // MapSlice encodes and decodes as a YAML map.
 // The order of keys is preserved when encoding and decoding.
@@ -332,7 +341,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 
 		info := fieldInfo{Num: i}
 
-		tag := field.Tag.Get(YAML_TAG)
+		tag := field.Tag.Get(yaml_tag)
 		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
 			tag = string(field.Tag)
 		}


### PR DESCRIPTION
I changed the yaml tag to default `yaml`, but added a new function "SetTag" to pass the tag desired value.
